### PR TITLE
:bug: Page breaks when daydream file is empty. etc..

### DIFF
--- a/src/app/admin/(modules)/daydreams/[daydreamId]/_components/EditDaydreamWrapper.tsx
+++ b/src/app/admin/(modules)/daydreams/[daydreamId]/_components/EditDaydreamWrapper.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { omit } from "lodash";
+import { omit, pick } from "lodash";
 import { DreamFormParams } from "@/features/daydreams/types";
 import { Fragment, Suspense, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
@@ -84,13 +84,13 @@ const EditDaydreamWrapper = () => {
           title="Edit Dream"
           item={{
             ...omit(daydreamData, "file"),
-            file_id: daydreamData.file.id,
-            file: {
-              id: daydreamData.file.id,
-              name: daydreamData.file.name,
-              bucket_name: daydreamData.file.bucket_name,
-              storage_file_path: daydreamData.file.storage_file_path,
-            },
+            file_id: daydreamData.file?.id || "",
+            file: pick(daydreamData.file || {}, [
+              "id",
+              "name",
+              "bucket_name",
+              "storage_file_path",
+            ]),
           }}
           onSubmit={onSubmitHandler}
           onDelete={onOpen}

--- a/src/app/admin/(modules)/daydreams/_components/DaydreamForm.tsx
+++ b/src/app/admin/(modules)/daydreams/_components/DaydreamForm.tsx
@@ -96,6 +96,11 @@ const DaydreamForm = ({
     if (!formState.isSubmitting) {
       setImage((item?.file as FileAPIDataStructure) ?? null);
     }
+
+    if (!item?.file_id) {
+      setValue("file_id", null);
+      setImage(null);
+    }
   }, [item]);
 
   const onSubmitHandler = async () => {

--- a/src/app/admin/(modules)/daydreams/_components/DaydreamTableRow.tsx
+++ b/src/app/admin/(modules)/daydreams/_components/DaydreamTableRow.tsx
@@ -23,9 +23,9 @@ export const DaydreamTableRow = ({
   isSelected,
 }: DaydreamTableRowProps) => {
   const { isOpen, onClose, onOpen } = useOpenable();
-  const { data, isLoading } = useStoragePublicUrl(item.file.storage_file_path);
+  const { isLoading } = useStoragePublicUrl(item.file?.storage_file_path || "");
 
-  if (isLoading || !data) {
+  if (isLoading) {
     return <DaydreamTableRowLoading />;
   }
 
@@ -33,23 +33,26 @@ export const DaydreamTableRow = ({
     <Fragment>
       <tr>
         <td className="text-center">
-          <div
-            className="relative aspect-square w-32 h-32 overflow-hidden flex items-center justify-center group"
-            onClick={onOpen}
-          >
-            <SupabaseImage
-              src={item.file.storage_file_path}
-              alt={item.file.name}
-              className="point-events-none absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 w-full h-full object-cover rounded-md"
-              quality={75}
-              width={480}
-              height={480}
-            />
+          {item.file ? (
+            <div
+              className="relative aspect-square w-32 h-32 overflow-hidden flex items-center justify-center group"
+              onClick={onOpen}
+            >
+              <SupabaseImage
+                src={item.file.storage_file_path}
+                alt={item.file.name}
+                className="point-events-none absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 w-full h-full object-cover rounded-md"
+                quality={75}
+                width={480}
+                height={480}
+              />
 
-            <ExpandImagePreviewPlaceholder />
-          </div>
+              <ExpandImagePreviewPlaceholder />
+            </div>
+          ) : (
+            <span className="relative aspect-square w-32 h-32 block bg-neutral-200 rounded-md" />
+          )}
         </td>
-        <td>{item.year}</td>
         <td>{item.description}</td>
         <td>
           <span className="block mb-1 whitespace-nowrap">{item.iso} ISO</span>

--- a/src/components/Select/SingleSimpleSelect.tsx
+++ b/src/components/Select/SingleSimpleSelect.tsx
@@ -35,8 +35,8 @@ export const SingleSimpleSelect = <
   value,
   placeholder,
   defaultValue,
-  optionValue = "text" as any,
-  optionText = "value" as any,
+  optionValue = "value" as any,
+  optionText = "text" as any,
 }: SingleSelectProps<ValueType, OptionItem>) => {
   const activeValue = value ?? defaultValue;
   const SelectedItem = options.find(

--- a/src/features/files/api/getStoragePublicUrl.ts
+++ b/src/features/files/api/getStoragePublicUrl.ts
@@ -8,7 +8,7 @@ export const getStoragePublicUrl = (path: string) => {
 export const useStoragePublicUrl = (path: string | undefined) =>
   useQuery({
     enabled: !!path,
-    staleTime: 0,
+    staleTime: Infinity,
 
     queryKey: ["file", path],
     queryFn: async (): Promise<string> => {


### PR DESCRIPTION
**BUG**
- Page breaks when daydream image is empty. Caused by deleting of the image resulted to file_id being null.
- SimpleSelect not showing selected option. 